### PR TITLE
bootstrap import fix due to crashing with ssr

### DIFF
--- a/src/components/BootstrapClientInit.tsx
+++ b/src/components/BootstrapClientInit.tsx
@@ -1,11 +1,20 @@
-"use client";
-import { useEffect } from "react";
-import "bootstrap-icons/font/bootstrap-icons.css";
-import "bootstrap/dist/js/bootstrap.bundle.js";
+'use client';
+import { useEffect } from 'react';
+import 'bootstrap-icons/font/bootstrap-icons.css';
 
 export const BootstrapClientInit = () => {
   useEffect(() => {
-    // import("bootstrap/dist/js/bootstrap.bundle");
+    // Import Bootstrap JS only on the client side
+    const loadBootstrap = async () => {
+      try {
+        // Import the main bootstrap module instead of the specific bundle
+        await import('bootstrap');
+        console.log('Bootstrap JS loaded successfully');
+      } catch (error) {
+        console.error('Failed to load Bootstrap JS:', error);
+      }
+    };
+    loadBootstrap();
     return;
   }, []);
 


### PR DESCRIPTION
app was crashing due to trying to load bootstrap too  early in the app without restriction.  Added to a useEffect to keep from rendering on server side, had to add into an additioanal async func to make ts happy.  all working now and back online